### PR TITLE
Handle avatars setup as the author of the Custom Avatars plugin directs people to do so

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7-apache-buster
 
 RUN apt-get update && \
   apt-get install -y libpq-dev python3 python3-pip libonig-dev && \
-  pip3 install unitypack && \
+  pip3 install git+ssh://git@github.com/HearthSim/UnityPack.git@f8cdc2516538d189606a76986ad2d71c3fad5f8b#egg=unitypack && \
   docker-php-ext-install pdo_pgsql exif mbstring && \
   cp -v "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
   echo "error_reporting = E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED" >> "$PHP_INI_DIR/conf.d/modelsaber.ini" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:7-apache-buster
 
 RUN apt-get update && \
-  apt-get install -y libpq-dev python3 python3-pip libonig-dev && \
-  pip3 install git+ssh://git@github.com/HearthSim/UnityPack.git@f8cdc2516538d189606a76986ad2d71c3fad5f8b#egg=unitypack && \
+  apt-get install -y libpq-dev python3 python3-pip libonig-dev git && \
+  pip3 install git+https://github.com/HearthSim/UnityPack.git@f8cdc2516538d189606a76986ad2d71c3fad5f8b#egg=unitypack && \
   docker-php-ext-install pdo_pgsql exif mbstring && \
   cp -v "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
   echo "error_reporting = E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED" >> "$PHP_INI_DIR/conf.d/modelsaber.ini" && \

--- a/Upload/getInfo.py
+++ b/Upload/getInfo.py
@@ -26,8 +26,18 @@ try:
                 elif object.type == "AvatarDescriptor":
                     fileType = "avatar"
                     data = object.read()
-                    objectName = data["AvatarName"]
-                    objectAuthor = data["AuthorName"]
+
+                    # Custom Avatars plugin changed where it stores name/author information
+                    # try newer location, and fallback to older location.
+                    if "name" in data:
+                        objectName = data["name"]
+                    else:
+                        objectName = data["AvatarName"]
+                    if "author" in data:
+                        objectAuthor = data["author"]
+                    else:
+                        objectAuthor = data["AuthorName"]
+
                     shouldstop = 1
                 elif object.type == "CustomPlatform":
                     fileType = "platform"


### PR DESCRIPTION
Updates unitypack, and adds a workaround for the name and author fields having been moved. You may prefer the latter not be done here, and instead ask the author of the Custom Avatars plugin to move the field back, but i think this should do the trick should that not be the route that you want to pursue.

I locked unitypack at a specific commit so that it doesn't change unexpectedly since we're referencing the git repository rather than an actual version. we can also choose to just always use the latest commit in the repository, but i chose to be conservative for the moment.